### PR TITLE
Enhance feed URL detection and add test for RSS feed subscription

### DIFF
--- a/lib/feed_searcher/fetcher.rb
+++ b/lib/feed_searcher/fetcher.rb
@@ -12,7 +12,7 @@ class FeedSearcher
     end
 
     def fetch
-      Page.new(get)
+      FeedSearcher::Page.new(get)
     end
 
     private

--- a/lib/feed_searcher/page.rb
+++ b/lib/feed_searcher/page.rb
@@ -20,7 +20,8 @@ class FeedSearcher
 
     def feed_urls
       urls = []
-      urls << url if like_xml? && parsable_as_xml? && has_feed_element?
+      urls << url if like_xml? && parsable_as_xml? && has_feed_element? 
+      urls << url if has_rss_element? && has_feed_element? && parsable_as_xml? && !urls.include?(url)
       urls += links.map {|link| link["href"] }
     end
 
@@ -28,6 +29,10 @@ class FeedSearcher
 
     def has_xml_declaration?
       !!body.start_with?("<?xml")
+    end
+
+    def has_rss_element?
+      !!root.xpath("//*[local-name()='rss']")
     end
 
     def has_feed_mime_type?

--- a/spec/feed_searcher_spec.rb
+++ b/spec/feed_searcher_spec.rb
@@ -3,6 +3,29 @@ require "active_support/core_ext/string/strip"
 
 describe FeedSearcher do
   describe ".search" do
+    it 'can subscribe to a feed of bokuyaba' do
+      stub_request(:get, "https://championcross.jp/series/899dda204c3f2/rss").to_return(body: <<~EOS
+        <rss xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:webfeeds="http://webfeeds.org/rss/1.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
+        <channel>
+          <title>僕の心のヤバイやつ【最新話無料】</title>
+          <link>https://championcross.jp/series/899dda204c3f2</link>
+          <atom:link rel="self" type="application/rss+xml" href="https://championcross.jp/series/899dda204c3f2/rss"/>
+          <copyright>僕の心のヤバイやつ【最新話無料】</copyright>
+          <webfeeds:icon>https://cdn-public.comici.jp/series/2/20240514165016604FC0B8E1EB60C6CC81C01AEC9EDC89401.png</webfeeds:icon>
+          <webfeeds:logo>https://cdn-public.comici.jp/series/2/20240514165016604FC0B8E1EB60C6CC81C01AEC9EDC89401.png</webfeeds:logo>
+          <webfeeds:accentColor>D80C24</webfeeds:accentColor>
+          <webfeeds:related layout="card" target="browser"/>
+          <webfeeds:analytics id="UA-114502607-1" engine="GoogleAnalytics"/>
+          <language>ja</language>
+          <pubDate>Tue, 09 Jul 2024 08:59:52 +0900</pubDate>
+          <lastBuildDate>Tue, 09 Jul 2024 08:59:52 +0900</lastBuildDate>
+        </channel>
+        </rss>
+      EOS
+      )
+      expect(FeedSearcher.search('https://championcross.jp/series/899dda204c3f2/rss').count).to eq 1
+    end
+
     context "when there are link elements of feeds in the resource" do
       before do
         stub_request(:get, "http://example.com/").to_return(


### PR DESCRIPTION
- Updated `fetch` method in `fetcher.rb` to use the fully qualified class name `FeedSearcher::Page`.
- Enhanced `feed_urls` method in `page.rb` to include URLs with RSS elements.
- Added `has_rss_element?` method in `page.rb` to check for the presence of RSS elements.
- Introduced a new test case in `feed_searcher_spec.rb` to verify the ability to subscribe to a specific RSS feed.